### PR TITLE
Add Spotify collector workflow

### DIFF
--- a/.github/workflows/spotify.yml
+++ b/.github/workflows/spotify.yml
@@ -1,0 +1,37 @@
+name: Collect Spotify history
+
+on:
+  schedule:
+    - cron: "*/10 * * * *"
+  workflow_dispatch:
+
+jobs:
+  scrape:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: spotify-scrape
+      cancel-in-progress: true
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - run: pip install -r requirements.txt
+
+    - run: python src/collector.py
+      env:
+        SPOTIFY_CLIENT_ID: ${{ secrets.SPOTIFY_CLIENT_ID }}
+        SPOTIFY_CLIENT_SECRET: ${{ secrets.SPOTIFY_CLIENT_SECRET }}
+        SPOTIFY_REFRESH_TOKEN: ${{ secrets.SPOTIFY_REFRESH_TOKEN }}
+
+    - name: Commit DB
+      uses: EndBug/add-and-commit@v9
+      with:
+        add: "data/history_*.db"
+        message: "chore: update Spotify history $(date -u +'%F %T')"
+        default_author: github_actions
+        author_name: ${{ secrets.GH_NAME }}
+        author_email: ${{ secrets.GH_EMAIL }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+spotipy
+python-dotenv

--- a/scripts/get_refresh_token.py
+++ b/scripts/get_refresh_token.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+"""Utility to generate a Spotify refresh token."""
+import os
+import spotipy.util as util
+
+TOKEN = util.prompt_for_user_token(
+    username=os.getenv("SPOTIFY_USER"),
+    scope="user-read-recently-played",
+    client_id=os.getenv("SPOTIFY_CLIENT_ID"),
+    client_secret=os.getenv("SPOTIFY_CLIENT_SECRET"),
+    redirect_uri="http://localhost:8888/callback",
+)
+print(TOKEN)

--- a/src/collector.py
+++ b/src/collector.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+import os
+import sqlite3
+import datetime
+import spotipy
+from spotipy.oauth2 import SpotifyOAuth
+
+# determine monthly DB path
+now = datetime.datetime.utcnow()
+db_name = f"history_{now.strftime('%Y%m')}.db"
+DB_PATH = os.path.join(os.path.dirname(__file__), "..", "data", db_name)
+
+conn = sqlite3.connect(DB_PATH)
+conn.execute("""CREATE TABLE IF NOT EXISTS plays (
+    played_at TEXT PRIMARY KEY,
+    track_id  TEXT,
+    track     TEXT,
+    artist    TEXT,
+    ms_played INTEGER
+)""")
+
+sp = spotipy.Spotify(auth_manager=SpotifyOAuth(
+    client_id=os.getenv("SPOTIFY_CLIENT_ID"),
+    client_secret=os.getenv("SPOTIFY_CLIENT_SECRET"),
+    redirect_uri="http://localhost:8888/callback",
+    scope="user-read-recently-played",
+    cache_path="/tmp/.spotify-cache"
+))
+
+for item in sp.current_user_recently_played(limit=50)["items"]:
+    row = (
+        item["played_at"],
+        item["track"]["id"],
+        item["track"]["name"],
+        ", ".join(a["name"] for a in item["track"]["artists"]),
+        item["ms_played"]
+    )
+    conn.execute("INSERT OR IGNORE INTO plays VALUES (?,?,?,?,?)", row)
+
+conn.commit()


### PR DESCRIPTION
## Summary
- scaffold repository directories
- add Spotify history collector with monthly DB rotation
- schedule workflow every 10 minutes
- helper script to generate refresh tokens
- document usage and workflow

## Testing
- `python3 -m pip install spotipy python-dotenv`
- `python3 -m py_compile src/collector.py scripts/get_refresh_token.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f87ca664c8331b730d81e1a0a47d3