### PR TITLE
Add contents write permissions

### DIFF
--- a/.github/workflows/spotify.yml
+++ b/.github/workflows/spotify.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: "*/10 * * * *"
   workflow_dispatch:
+permissions:
+  contents: write
 
 jobs:
   scrape:

--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ on:
     - cron: "*/10 * * * *"
   workflow_dispatch:  # manual trigger for testing
 
+permissions:
+  contents: write
+
 jobs:
   scrape:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- grant contents write permissions in workflow
- document the permissions block in the README workflow example

## Testing
- `python -m py_compile src/*.py scripts/*.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683fa2a06be48331a204b425fb7598f9