### PR TITLE
Fix monthly DB commits

### DIFF
--- a/.github/workflows/spotify.yml
+++ b/.github/workflows/spotify.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Commit DB
       uses: EndBug/add-and-commit@v9
       with:
-        add: "data/history_*.db"
+        add: "data/history_*.db --force"
         message: "chore: update Spotify history $(date -u +'%F %T')"
         default_author: github_actions
         author_name: ${{ secrets.GH_NAME }}


### PR DESCRIPTION
## Summary
- force-add new monthly SQLite files so they're committed even when the name changes

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863dc24ddb08331b51e8cefe7ca9a97